### PR TITLE
[CLASSIC-18439] Removed JAI from Batik by copying the class we need

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  patchBaseVersion: 1.11-assentis-4 # Carefully review before PR
+  patchBaseVersion: 1.11-assentis-5 # Carefully review before PR
 
 steps:
 

--- a/batik-bridge/pom.xml
+++ b/batik-bridge/pom.xml
@@ -77,6 +77,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>batik-svggen</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>batik-util</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -106,11 +111,6 @@
       <artifactId>rhino</artifactId>
       <version>${rhino.version}</version>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_core</artifactId>
-      <version>1.1.3</version>
     </dependency>
   </dependencies>
 

--- a/batik-bridge/src/main/java/org/apache/batik/bridge/PaintServer.java
+++ b/batik-bridge/src/main/java/org/apache/batik/bridge/PaintServer.java
@@ -28,7 +28,7 @@ import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
 import java.io.IOException;
 
-import com.sun.media.jai.util.SimpleCMYKColorSpace;
+import org.apache.batik.svggen.SimpleCMYKColorSpace;
 
 import org.apache.batik.css.engine.SVGCSSEngine;
 import org.apache.batik.css.engine.value.Value;

--- a/batik-svggen/pom.xml
+++ b/batik-svggen/pom.xml
@@ -45,11 +45,6 @@
       <artifactId>batik-util</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_core</artifactId>
-      <version>1.1.3</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SVGColor.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SVGColor.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.batik.ext.awt.g2d.GraphicContext;
-import com.sun.media.jai.util.SimpleCMYKColorSpace;
 
 /**
  * Utility class that converts a Color object into a set of

--- a/batik-svggen/src/main/java/org/apache/batik/svggen/SimpleCMYKColorSpace.java
+++ b/batik-svggen/src/main/java/org/apache/batik/svggen/SimpleCMYKColorSpace.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2005 Sun Microsystems, Inc. All  Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * - Redistribution of source code must retain the above copyright
+ *   notice, this  list of conditions and the following disclaimer.
+ *
+ * - Redistribution in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * Neither the name of Sun Microsystems, Inc. or the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MIDROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF
+ * USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
+ * CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
+ * REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
+ * INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS BEEN ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed or intended for
+ * use in the design, construction, operation or maintenance of any
+ * nuclear facility.
+ *
+ */
+package org.apache.batik.svggen;
+
+import java.awt.color.ColorSpace;
+
+/**
+ * Singleton class representing a simple, mathematically defined CMYK
+ * color space.
+ */
+public final class SimpleCMYKColorSpace extends ColorSpace {
+    private static ColorSpace theInstance = null;
+    private ColorSpace csRGB;
+
+    /** The exponent for gamma correction. */
+    private static final double power1 = 1.0 / 2.4;
+
+    public static final synchronized ColorSpace getInstance() {
+        if(theInstance == null) {
+            theInstance = new SimpleCMYKColorSpace();
+        }
+        return theInstance;
+    }
+
+    private SimpleCMYKColorSpace() {
+        super(TYPE_CMYK, 4);
+        csRGB = ColorSpace.getInstance(ColorSpace.CS_LINEAR_RGB);
+    }
+
+    public boolean equals(Object o) {
+        return o != null && o instanceof SimpleCMYKColorSpace;
+    }
+
+    public float[] toRGB(float[] colorvalue) {
+        float C = colorvalue[0];
+        float M = colorvalue[1];
+        float Y = colorvalue[2];
+        float K = colorvalue[3];
+
+        float K1 = 1.0F - K;
+
+        // Convert from CMYK to linear RGB.
+        float[] rgbvalue = new float[] {K1*(1.0F - C),
+                K1*(1.0F - M),
+                K1*(1.0F - Y)};
+
+        // Convert from linear RGB to sRGB.
+        for (int i = 0; i < 3; i++) {
+            float v = rgbvalue[i];
+
+            if (v < 0.0F) v = 0.0F;
+
+            if (v < 0.0031308F) {
+                rgbvalue[i] = 12.92F * v;
+            } else {
+                if (v > 1.0F) v = 1.0F;
+
+                rgbvalue[i] = (float)(1.055 * Math.pow(v, power1) - 0.055);
+            }
+        }
+
+        return rgbvalue;
+    }
+
+    public float[] fromRGB(float[] rgbvalue) {
+        // Convert from sRGB to linear RGB.
+        for (int i = 0; i < 3; i++) {
+            if (rgbvalue[i] < 0.040449936F) {
+                rgbvalue[i] /= 12.92F;
+            } else {
+                rgbvalue[i] = (float)(Math.pow((rgbvalue[i] + 0.055)/1.055, 2.4));
+            }
+        }
+
+        // Convert from linear RGB to CMYK.
+        float C = 1.0F - rgbvalue[0];
+        float M = 1.0F - rgbvalue[1];
+        float Y = 1.0F - rgbvalue[2];
+        float K = Math.min(C, Math.min(M, Y));
+
+        // If K == 1.0F, then C = M = Y = 1.0F.
+        if(K != 1.0F) {
+            float K1 = 1.0F - K;
+
+            C = (C - K)/K1;
+            M = (M - K)/K1;
+            Y = (Y - K)/K1;
+        } else {
+            C = M = Y = 0.0F;
+        }
+
+        return new float[] {C, M, Y, K};
+    }
+
+    public float[] toCIEXYZ(float[] colorvalue) {
+        return csRGB.toCIEXYZ(toRGB(colorvalue));
+    }
+
+    public float[] fromCIEXYZ(float[] xyzvalue) {
+        return fromRGB(csRGB.fromCIEXYZ(xyzvalue));
+    }
+}


### PR DESCRIPTION
Batik uses only one JAI class - SimpleCMYKColorSpace. It seems to me that there is no simple way of imitating its functionality so after conversation with Guido we concluded that copying the one class that we need is the simplest solution.